### PR TITLE
Use type-based service dictionaries

### DIFF
--- a/Runtime/Scripts/Managers/UIManager.cs
+++ b/Runtime/Scripts/Managers/UIManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -6,7 +7,7 @@ namespace MyUnityPackage.Toolkit
     public static class UIManager
     {
         // Stores the mapping between UI component types and their instances (e.g., Canvas, custom UI scripts)
-        private static Dictionary<object, object> canvasUI = new Dictionary<object, object>(); // store type and component
+        private static Dictionary<Type, UnityEngine.Object> canvasUI = new Dictionary<Type, UnityEngine.Object>(); // store type and component
         // Stores all loaded transitions by name for quick access
         private static Dictionary<string, TransitionSO> transitions = new Dictionary<string, TransitionSO>();
 
@@ -34,7 +35,7 @@ namespace MyUnityPackage.Toolkit
         {
             //Init the dictionary
             if (canvasUI == null)
-                canvasUI = new Dictionary<object, object>();
+                canvasUI = new Dictionary<Type, UnityEngine.Object>();
 
             try
             {
@@ -45,12 +46,12 @@ namespace MyUnityPackage.Toolkit
                     if (cui == null) //The key exist but reference object doesn't exist anymore
                     {
                         canvasUI.Remove(typeof(T)); //Remove this key from the dictonary
-                        canvasUI.Add(typeof(T), go.GetComponent<T>());
+                        canvasUI.Add(typeof(T), (UnityEngine.Object)go.GetComponent<T>());
                     }
                 }
                 else
                 {
-                    canvasUI.Add(typeof(T), go.GetComponent<T>());
+                    canvasUI.Add(typeof(T), (UnityEngine.Object)go.GetComponent<T>());
                 }
             }
             catch
@@ -64,7 +65,7 @@ namespace MyUnityPackage.Toolkit
         {
             //Init the dictionary
             if (canvasUI == null)
-                canvasUI = new Dictionary<object, object>();
+                canvasUI = new Dictionary<Type, UnityEngine.Object>();
 
             try
             {
@@ -84,7 +85,7 @@ namespace MyUnityPackage.Toolkit
                 }
                 else
                 {
-                   MUPLogger.LogMessageWarningEditor("Can't find requested canvas UI");
+                    MUPLogger.LogMessageWarningEditor("Can't find requested canvas UI");
                     return null;
                 }
             }
@@ -111,7 +112,7 @@ namespace MyUnityPackage.Toolkit
             }
             else
             {
-               MUPLogger.LogMessageWarningEditor("Transition not found: " + transitionName + " check if this transition is in resource folder");
+                MUPLogger.LogMessageWarningEditor("Transition not found: " + transitionName + " check if this transition is in resource folder");
             }
         }
         // Play a transition by triggering an Animator parameter on the given canvas

--- a/Runtime/Scripts/Static/ServiceLocator.cs
+++ b/Runtime/Scripts/Static/ServiceLocator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace MyUnityPackage.Toolkit
@@ -6,135 +7,135 @@ namespace MyUnityPackage.Toolkit
     public static class ServiceLocator
     {
         //Hold Reference to all found services as type as key , and reference to the concerete object
-    static Dictionary<object, object> servicecontainer = null;
+        static Dictionary<Type, UnityEngine.Object> servicecontainer = null;
 
-    /// <summary>
-    /// Find a service/script in current scene and return reference of it , Note: it will still find the service even if it's unactive
-    /// </summary>
-    /// <typeparam name="T">Type of service to find</typeparam>
-    /// <returns></returns>
-    public static T GetService<T>(bool createObjectIfNotFound = false) where T : Object
-    {
-        //Init the dictionary
-        if (servicecontainer == null)
-            servicecontainer = new Dictionary<object, object>();
-
-        try
+        /// <summary>
+        /// Find a service/script in current scene and return reference of it , Note: it will still find the service even if it's unactive
+        /// </summary>
+        /// <typeparam name="T">Type of service to find</typeparam>
+        /// <returns></returns>
+        public static T GetService<T>(bool createObjectIfNotFound = false) where T : Object
         {
-            //Check if the key exist in the dictionary
-            if (servicecontainer.ContainsKey(typeof(T)))
+            //Init the dictionary
+            if (servicecontainer == null)
+                servicecontainer = new Dictionary<Type, UnityEngine.Object>();
+
+            try
             {
-                T service = (T)servicecontainer[typeof(T)];
-                if (service != null) //If Key exist and the object it reference to still exist
+                //Check if the key exist in the dictionary
+                if (servicecontainer.ContainsKey(typeof(T)))
                 {
-                    return service;
+                    T service = (T)servicecontainer[typeof(T)];
+                    if (service != null) //If Key exist and the object it reference to still exist
+                    {
+                        return service;
+                    }
+                    else //The key exist but reference object doesn't exist anymore
+                    {
+                        servicecontainer.Remove(typeof(T)); //Remove this key from the dictonary
+                        return FindService<T>(createObjectIfNotFound); //Try and find the service in current scene
+                    }
                 }
-                else //The key exist but reference object doesn't exist anymore
+                else
                 {
-                    servicecontainer.Remove(typeof(T)); //Remove this key from the dictonary
-                    return FindService<T>(createObjectIfNotFound); //Try and find the service in current scene
-                }
-            }
-            else
-            {
-                return FindService<T>(createObjectIfNotFound);
-            }
-        }
-        catch
-        {
-            throw new System.InvalidOperationException($"Can't find requested service of type {typeof(T).Name}, and create new one is set to {createObjectIfNotFound}");
-        }
-    }
-
-
-    /// <summary>
-    /// Add a service/script
-    /// </summary>
-    /// <typeparam name="T">Type of service to add</typeparam>
-    /// <param name="go">GameObject of service to add</param>
-    public static void AddService<T>(GameObject go) where T : Object
-    {
-        //Init the dictionary
-        if (servicecontainer == null)
-            servicecontainer = new Dictionary<object, object>();
-
-        try
-        {
-            //Check if the key exist in the dictionary
-            if (servicecontainer.ContainsKey(typeof(T)))
-            {
-                T service = (T)servicecontainer[typeof(T)];
-                if (service == null) //The key exist but reference object doesn't exist anymore
-                {
-                    servicecontainer.Remove(typeof(T)); //Remove this key from the dictonary
-                    servicecontainer.Add(typeof(T), go.GetComponent<T>());
+                    return FindService<T>(createObjectIfNotFound);
                 }
             }
-            else
+            catch
             {
-                servicecontainer.Add(typeof(T), go.GetComponent<T>());
+                throw new System.InvalidOperationException($"Can't find requested service of type {typeof(T).Name}, and create new one is set to {createObjectIfNotFound}");
             }
         }
-        catch
-        {
-            throw new System.InvalidOperationException($"The requested service of type {typeof(T).Name} is already referenced");
-        }
-    }
 
-    /// <summary>
-    /// Check if a service is already referenced
-    /// </summary>
-    /// <returns>If a service is already referenced</returns>
-    public static bool Exists<T>() where T : Object
-    {
-        //Init the dictionary
-        if (servicecontainer == null)
-            servicecontainer = new Dictionary<object, object>();
 
-        try
+        /// <summary>
+        /// Add a service/script
+        /// </summary>
+        /// <typeparam name="T">Type of service to add</typeparam>
+        /// <param name="go">GameObject of service to add</param>
+        public static void AddService<T>(GameObject go) where T : Object
         {
-            //Check if the key exist in the dictionary
-            if (servicecontainer.ContainsKey(typeof(T)))
+            //Init the dictionary
+            if (servicecontainer == null)
+                servicecontainer = new Dictionary<Type, UnityEngine.Object>();
+
+            try
             {
-                return true;
+                //Check if the key exist in the dictionary
+                if (servicecontainer.ContainsKey(typeof(T)))
+                {
+                    T service = (T)servicecontainer[typeof(T)];
+                    if (service == null) //The key exist but reference object doesn't exist anymore
+                    {
+                        servicecontainer.Remove(typeof(T)); //Remove this key from the dictonary
+                        servicecontainer.Add(typeof(T), (UnityEngine.Object)go.GetComponent<T>());
+                    }
+                }
+                else
+                {
+                    servicecontainer.Add(typeof(T), (UnityEngine.Object)go.GetComponent<T>());
+                }
             }
-            else
+            catch
             {
-                return false;
+                throw new System.InvalidOperationException($"The requested service of type {typeof(T).Name} is already referenced");
             }
         }
-        catch
-        {
-            throw new System.InvalidOperationException("An error has occurred while checking service existence.");
-        }
-    }
 
-    /// <summary>
-    /// Look for a game object with type required
-    /// </summary>
-    /// <typeparam name="T">Type to look for</typeparam>
-    /// <param name="createObjectIfNotFound">Either create a gameobject with type if not exist</param>
-    /// <returns></returns>
-    static T FindService<T>(bool createObjectIfNotFound = false) where T : Object
-    {
-        T type = GameObject.FindAnyObjectByType<T>();
-        if (type != null)
+        /// <summary>
+        /// Check if a service is already referenced
+        /// </summary>
+        /// <returns>If a service is already referenced</returns>
+        public static bool Exists<T>() where T : Object
         {
-            //If found add it to the dictonary
-            servicecontainer.Add(typeof(T), type);
-        }
-        else if (createObjectIfNotFound)
-        {
-            //If not found and set to create new gameobject , create a new gameobject and add the type to it
-            GameObject go = new GameObject(typeof(T).Name, typeof(T));
-            servicecontainer.Add(typeof(T), go.GetComponent<T>());
-        }
-        return (T)servicecontainer[typeof(T)];
-    }
+            //Init the dictionary
+            if (servicecontainer == null)
+                servicecontainer = new Dictionary<Type, UnityEngine.Object>();
 
-    public static void Clear()
-    {
-        servicecontainer.Clear();
-    }
+            try
+            {
+                //Check if the key exist in the dictionary
+                if (servicecontainer.ContainsKey(typeof(T)))
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                throw new System.InvalidOperationException("An error has occurred while checking service existence.");
+            }
+        }
+
+        /// <summary>
+        /// Look for a game object with type required
+        /// </summary>
+        /// <typeparam name="T">Type to look for</typeparam>
+        /// <param name="createObjectIfNotFound">Either create a gameobject with type if not exist</param>
+        /// <returns></returns>
+        static T FindService<T>(bool createObjectIfNotFound = false) where T : Object
+        {
+            T type = GameObject.FindAnyObjectByType<T>();
+            if (type != null)
+            {
+                //If found add it to the dictonary
+                servicecontainer.Add(typeof(T), (UnityEngine.Object)type);
+            }
+            else if (createObjectIfNotFound)
+            {
+                //If not found and set to create new gameobject , create a new gameobject and add the type to it
+                GameObject go = new GameObject(typeof(T).Name, typeof(T));
+                servicecontainer.Add(typeof(T), (UnityEngine.Object)go.GetComponent<T>());
+            }
+            return (T)servicecontainer[typeof(T)];
+        }
+
+        public static void Clear()
+        {
+            servicecontainer?.Clear();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the service locator's object/object dictionary with a Dictionary<Type, UnityEngine.Object> and adjust initialization, inserts, and retrievals
- update UIManager's canvas registry to use Type keys and UnityEngine.Object values with explicit casts when adding components

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c970205594832f90f7c62ec0475261