### PR TITLE
Include inactive objects when locating services

### DIFF
--- a/Runtime/Scripts/Static/ServiceLocator.cs
+++ b/Runtime/Scripts/Static/ServiceLocator.cs
@@ -10,7 +10,7 @@ namespace MyUnityPackage.Toolkit
         static Dictionary<Type, UnityEngine.Object> servicecontainer = null;
 
         /// <summary>
-        /// Find a service/script in current scene and return reference of it , Note: it will still find the service even if it's unactive
+        /// Find a service/script in current scene and return reference of it. Note: this will also locate inactive services.
         /// </summary>
         /// <typeparam name="T">Type of service to find</typeparam>
         /// <returns></returns>
@@ -118,7 +118,7 @@ namespace MyUnityPackage.Toolkit
         /// <returns></returns>
         static T FindService<T>(bool createObjectIfNotFound = false) where T : Object
         {
-            T type = GameObject.FindAnyObjectByType<T>();
+            T type = GameObject.FindAnyObjectByType<T>(FindObjectsInactive.Include);
             if (type != null)
             {
                 //If found add it to the dictonary


### PR DESCRIPTION
## Summary
- ensure ServiceLocator can find inactive objects by using FindAnyObjectByType with FindObjectsInactive.Include
- clarify documentation to note inactive services are also located

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c97c6a44ec832fa2e06c0b1a14ce2f