### PR TITLE
Sync audio mute state with AudioManager

### DIFF
--- a/Runtime/Scripts/Audio/AudioUpdater.cs
+++ b/Runtime/Scripts/Audio/AudioUpdater.cs
@@ -34,7 +34,8 @@ namespace MyUnityPackage.Toolkit
                 slider.maxValue = 1f;
             }
             
-            if (isMuted)
+            var audioSettings = AudioManager.GetAudioSettingsFromAudioType(audioType);
+            if (audioSettings != null && isMuted != audioSettings.isMuted)
             {
                 AudioManager.ToggleMute(audioType);
             }
@@ -60,6 +61,8 @@ namespace MyUnityPackage.Toolkit
             AudioManager.SetVolume(audioType, audioSettingsSO.defaultVolume);
             UpdateVolumeText(audioSettingsSO.defaultVolume);
             UpdateMuteText(audioSettingsSO.defaultVolume);
+            isMuted = AudioManager.GetAudioSettingsFromAudioType(audioType).isMuted;
+            UpdateMuteImage();
         }
 
         // Called when the volume slider value changes
@@ -75,15 +78,18 @@ namespace MyUnityPackage.Toolkit
         {
             Debug.Log("OnMuteClicked");
             AudioManager.ToggleMute(audioType);
-
+            isMuted = AudioManager.GetAudioSettingsFromAudioType(audioType).isMuted;
             MUPLogger.LogMessage(audioType.ToString() + " isMuted: " + isMuted.ToString());
+
+            float currentVolume = AudioManager.GetVolume(audioType);
             if (slider != null)
             {
-                slider.value = AudioManager.GetVolume(audioType);
-                UpdateVolumeText(slider.value);
+                slider.value = currentVolume;
+                UpdateVolumeText(currentVolume);
             }
-            UpdateMuteText(slider.value);
-            
+            UpdateMuteText(currentVolume);
+            UpdateMuteImage();
+
         }
 
         // Updates the volume text UI to reflect the current value


### PR DESCRIPTION
## Summary
- align the AudioUpdater mute flag with the AudioManager state during initialization and after mute toggles
- refresh the mute UI elements using the AudioManager volume information, including updating the button image on init

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c97be479e8832fb722c9ac55855134